### PR TITLE
Update the lint-staged (to match other projects)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - install
       - run: yarn test
-      - run: yarn lint
+      - run: yarn lint:check
       - run: yarn format:check
       - run: .circleci/yarn-audit.sh
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ The code is linted with:
 - [ESLint](https://eslint.org/) (linting)
 - [Prettier](https://prettier.io/) (formatting)
 
-There is a [`yarn lint` and `yarn format:check` tasks](./package.json) that runs JS/TS linting on every build.<br/>
-There is also a [`yarn lint:fix` and `yarn format` tasks](./package.json) that run on staged files on a pre-commit
-hook to automatically fix TS linting issues.
+There are [`yarn lint:check` and `yarn format:check` tasks](./package.json) that runs linting checks on every build.<br/>
+There are also [`yarn lint` and `yarn format` tasks](./package.json) that run on staged files on a `pre-commit`
+hook to automatically fix linting issues (when possible).
 
 ## Publishing
 With every tag release the package is automatically published to NPM (automated through CircleCI)

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  "./src/**/*.{ts,tsx}": ["yarn format", "yarn lint:fix"],
-  "./*.{config,setup}.{js,ts}": ["yarn format", "yarn lint:fix"],
+  "./src/**/*.{ts,tsx}": ["yarn format", "yarn lint"],
+  "./*.{config,setup}.{js,ts}": ["yarn format", "yarn lint"],
 };

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "build": "rollup -c",
     "_eslint": "eslint --ext .ts --ext .tsx .",
     "_prettier": "prettier --check './src/**/*.{ts,tsx,js,jsx}'",
-    "format": "yarn _prettier --write",
     "format:check": "yarn _prettier",
-    "lint": "yarn _eslint",
-    "lint:fix": "yarn _eslint --fix",
+    "format": "yarn _prettier --write",
+    "lint:check": "yarn _eslint",
+    "lint": "yarn _eslint --fix",
     "test": "jest",
     "build:storybook": "build-storybook",
     "start:storybook": "start-storybook -p 9009"


### PR DESCRIPTION
## Proposed changes
Update the linting (`lint-staged`) to match other projects
Separate the `lint`/`format` tasks and provide a `(lint|format):check` tasks for CI to run on every builds
### Technical
- 🔧 Update the linting (`lint-staged`) to match other projects
