### PR TITLE
Fix/remove create react app settings

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,14 +18,6 @@ module.exports = {
     "@storybook/addon-actions",
     "@storybook/addon-links",
     {
-      name: "@storybook/preset-create-react-app",
-      options: {
-        tsDocgenLoaderOptions: {
-          tsconfigPath: path.resolve(__dirname, "../tsconfig.json"),
-        },
-      },
-    },
-    {
       name: "@storybook/addon-docs",
       options: {
         configureJSX: true,

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
       "pre-commit": "lint-staged"
     }
   },
-  "dependencies": {
-    "sapera-components": "file:"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sapera-components",
-  "version": "0.0.1-development",
+  "version": "0.0.2-development",
   "description": "Sapera Design System and Storybook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
       "pre-commit": "lint-staged"
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "sapera-components": "file:"
+  },
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10689,11 +10689,6 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-"sapera-components@file:.":
-  version "0.0.2-development"
-  dependencies:
-    sapera-components "file:../../Library/Caches/Yarn/v6/npm-sapera-components-0.0.2-development-2bb55293-685b-4b20-858b-2f30d905040d-1587019533650/node_modules/sapera-components"
-
 sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10689,6 +10689,11 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+"sapera-components@file:.":
+  version "0.0.2-development"
+  dependencies:
+    sapera-components "file:../../Library/Caches/Yarn/v6/npm-sapera-components-0.0.2-development-2bb55293-685b-4b20-858b-2f30d905040d-1587019533650/node_modules/sapera-components"
+
 sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"


### PR DESCRIPTION
## Proposed changes

This Pull Request removes pasted [@storybook/preset-create-react-app](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app) configuration from the archived repo and updates the version tag for release.

### Bug Fixes
- 🐛 Remove [@storybook/preset-create-react-app](https://github.com/storybookjs/presets/tree/master/packages/preset-create-react-app) configuration from the archived repo.

### Other
- 🔖 Update version tag from _0.0.1-development_ to _0.0.2-development_ for release.