### PR TITLE
fix: remove trailing whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ yarn add sapera-components@^0.0.1-development
 import { Button } from "sapera-components";
 ```
 
-`sapera-components` provides an integrated TypeScript experience out of the box.<br/>	
-The types for each component is provided (following the pattern `{Component}Props` and can be imported for	
-type-checking while developing.	
+`sapera-components` provides an integrated TypeScript experience out of the box.<br/>
+The types for each component is provided (following the pattern `{Component}Props` and can be imported for
+type-checking while developing.
 
-```javascript	
-import { Button, ButtonProps } from "sapera-components";	
+```javascript
+import { Button, ButtonProps } from "sapera-components";
 ```
 
 ## General Notes


### PR DESCRIPTION
## Proposed changes

This Pull Request removes trailing whitespaces in the readme file, as per [discussed](https://github.com/infographicsgroup/sapera-components/pull/3#discussion_r409425098).

### Bug Fixes

- 🐛 Remove trailing whitespaces in readme file.