### PR TITLE
Add the missing FlexboxProps (exported from styled-system)

### DIFF
--- a/src/components/Flexbox/Flexbox.tsx
+++ b/src/components/Flexbox/Flexbox.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { flexbox, FlexboxProps } from "styled-system";
 
+export type { FlexboxProps };
 export const Flexbox = styled.div<FlexboxProps>(
   {
     display: "flex",

--- a/src/components/Flexbox/index.ts
+++ b/src/components/Flexbox/index.ts
@@ -1,3 +1,4 @@
-import { Flexbox } from "./Flexbox";
+import { Flexbox, FlexboxProps } from "./Flexbox";
 
 export { Flexbox };
+export type { FlexboxProps };


### PR DESCRIPTION
## Proposed changes

Adding this for completeness and to avoid memoizing where the package is
exported...
This to allow the following code
```
import { Button, ButtonProps, Flexbox, FlexboxProps } from "sapera-components"
```
as opposed to

```
import { Button, ButtonProps, Flexbox } from "sapera-components"
import { FlexboxProps } from "styled-system"
```

## Text for the Changelog
Add the missing FlexboxProps (exported from styled-system)
