### PR TITLE
Chore/strict type checking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,13 @@ module.exports = {
     ],
     "comma-dangle": ["error", "always-multiline"],
     "no-unused-vars": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-function-return-type": ["error",
+      {
+        allowExpressions: true, // this is to allow using expressions with styled-components
+        allowTypedFunctionExpressions: true,
+        allowHigherOrderFunctions: true,
+      }
+    ],
     quotes: ["error", "double"],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",

--- a/src/components/Button/Icon.tsx
+++ b/src/components/Button/Icon.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 // eslint-disable-next-line react/prop-types
-const Icon = ({ width = "100%", height = "", viewBox = "0 0 20 20" }) => {
+const Icon = ({ width = "100%", height = "", viewBox = "0 0 20 20" }): JSX.Element => {
   return (
     <svg height={height} viewBox={viewBox} width={width}>
       <path


### PR DESCRIPTION
## Proposed changes

Having a stricter linting rule (that doesn't collide with styled-system/component expressions)
In response to my earlier [comment](https://github.com/infographicsgroup/sapera-components/pull/10#pullrequestreview-401718053) on #10 

### Technical

- 🔧 Stricter linting rule