### PR TITLE
Chore/lint staged js ts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,16 +19,11 @@ module.exports = {
   },
   plugins: ["react", "react-hooks", "@typescript-eslint", "jest"],
   rules: {
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        argsIgnorePattern: "^_",
-        varsIgnorePattern: "^_",
-      },
-    ],
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-var-requires": "off",
     "comma-dangle": ["error", "always-multiline"],
     "no-unused-vars": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
     quotes: ["error", "double"],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
@@ -50,6 +45,21 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ["*.ts", "*.tsx"],
+      rules: {
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            argsIgnorePattern: "^_",
+            varsIgnorePattern: "^_",
+          },
+        ],
+        "@typescript-eslint/no-var-requires": "error",
+      },
+    },
+  ],
   settings: {
     react: {
       version: "detect",

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,3 @@
-// TODO: fix No props found when using docs addon
 const path = require("path");
 
 module.exports = {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
 import { addDecorator } from "@storybook/react";
-import { withInfo } from '@storybook/addon-info';
+import { withInfo } from "@storybook/addon-info";
 
 addDecorator(withInfo);

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  "./src/**/*.{ts,tsx}": ["yarn format", "yarn lint"],
-  "./*.{config,setup}.{js,ts}": ["yarn format", "yarn lint"],
+  "./{src,.storybook}/**/*.{ts,tsx,js,jsx}": ["yarn format", "yarn lint"],
+  "./*.{js,ts}": ["yarn format ./*.{js,ts}", "yarn lint ./*.{js,ts}"],
 };

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "license": "MIT",
   "scripts": {
     "build": "rollup -c",
-    "_eslint": "eslint --ext .ts --ext .tsx .",
-    "_prettier": "prettier --check './src/**/*.{ts,tsx,js,jsx}'",
+    "_eslint": "eslint './{src,.storybook}/**/*.{ts,tsx,js,jsx}'",
+    "_prettier": "prettier --check './{src,.storybook}/**/*.{ts,tsx,js,jsx}'",
     "format:check": "yarn _prettier",
     "format": "yarn _prettier --write",
     "lint:check": "yarn _eslint",


### PR DESCRIPTION
## Proposed changes

Modification to lint-staged automation to
- Expand the checking to include config and js files and exclude dist folder
- [Configuration for mixed js/ts codebases](https://github.com/typescript-eslint/typescript-eslint/blob/v2.30.0/packages/eslint-plugin/docs/rules/explicit-function-return-type.md#configuring-in-a-mixed-jsts-codebase)
- liniting of the `.storybook` js files and adding them to the automated process