### PR TITLE
feat: add optional bg color prop for buttons

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -15,7 +15,9 @@ const downloadIcon = <Icon width={"25px"} />;
 export const TextButtons: React.FunctionComponent = () => (
   <div style={{ display: "flex", justifyContent: "space-around" }}>
     <div>
-      <Button onClick={action("clicked")}>primary lg</Button>
+      <Button bg={"purple"} onClick={action("clicked")}>
+        primary lg
+      </Button>
       <br />
       <Button size={"medium"} onClick={action("clicked")}>
         primary md
@@ -30,7 +32,7 @@ export const TextButtons: React.FunctionComponent = () => (
         Secondary lg
       </Button>
       <br />
-      <Button size={"medium"} isSecondary onClick={action("clicked")}>
+      <Button bg={"yellow"} size={"medium"} isSecondary onClick={action("clicked")}>
         Secondary md
       </Button>
       <br />

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import styled, { css } from "styled-components";
-import { Color } from "../../theme/util";
+import { Color, ColorType } from "../../theme/util";
 
 // https://www.w3schools.com/tags/tag_button.asp
 export interface ButtonProps {
@@ -12,6 +12,7 @@ export interface ButtonProps {
   className?: string;
   disabled?: boolean;
   name?: string;
+  bg?: string | ColorType | undefined;
   iconFirst?: boolean;
   tabIndex?: string;
   size?: "large" | "medium" | "small";
@@ -41,7 +42,7 @@ const StyledButton = styled.button<ButtonProps>`
   height: ${(p) => (p.size ? BUTTON_HEIGHTS[p.size] + "px" : BUTTON_HEIGHTS.large + "px")};
   border-radius: 28px;
   color: ${Color.TextInverted};
-  background: ${Color.Primary};
+  background: ${(p) => p.bg};
   border: none;
   font-size: 16px;
   letter-spacing: 1px;
@@ -62,7 +63,7 @@ const StyledButton = styled.button<ButtonProps>`
     p.isSecondary &&
     css`
       color: ${Color.Primary};
-      background: ${Color.BackgroundMain};
+      background: ${(p) => p.bg};
       border: 1.25px solid ${Color.Primary};
       svg,
       path {
@@ -96,6 +97,7 @@ export const Button: FC<ButtonProps> = ({
   size = "large",
   iconFirst = false,
   isSecondary = false,
+  bg = isSecondary ? Color.BackgroundMain : Color.Primary,
   value,
 }: ButtonProps) => {
   // aria-label atrribute usage
@@ -106,6 +108,7 @@ export const Button: FC<ButtonProps> = ({
       aria-label={ariaLabel || undefined}
       aria-pressed={ariaPressed}
       autoFocus={autoFocus}
+      bg={bg}
       className={className}
       disabled={disabled}
       iconFirst={iconFirst}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -97,7 +97,7 @@ export const Button: FC<ButtonProps> = ({
   size = "large",
   iconFirst = false,
   isSecondary = false,
-  bg = isSecondary ? Color.BackgroundMain : Color.Primary,
+  bg = isSecondary ? "none" : Color.Primary,
   value,
 }: ButtonProps) => {
   // aria-label atrribute usage


### PR DESCRIPTION
## Proposed changes

Updates the button component in Sapera Storybook to accept a custom bg color and change the default background for the secondary button to be transparent. 

<img width="1088" alt="Screen Shot 2020-05-11 at 13 59 28" src="https://user-images.githubusercontent.com/15083303/81559636-0f54a280-9390-11ea-8e5a-f683d54637d5.png">

### Technical

- 🔧 Add bg prop to button
- 🌈 Updates button story to demo
