### PR TITLE
Chore/data types bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-test-renderer": "^16.13.1",
     "regenerator-runtime": "^0.13.5",
     "rollup": "^1.27.12",
+    "rollup-plugin-dts": "^1.4.2",
     "rollup-plugin-typescript2": "^0.27.0",
     "styled-components": "4.4.1",
     "styled-system": "^5.1.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,19 +2,22 @@ import typescript from "rollup-plugin-typescript2";
 import dts from "rollup-plugin-dts";
 const pkg = require("./package.json");
 
+// Only package.json dependencies section is considered internal, other dependencies should be external/excluded
+const externalDependencies = [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})];
+
 export default [
   // Typescript
   {
     input: ["src/index.ts"],
     output: [{ file: pkg.main, format: "cjs", sourcemap: true }],
-    external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
+    external: externalDependencies,
     plugins: [typescript({ clean: true })],
   },
   // Data type declarations
   {
     input: ["src/index.ts"],
     output: [{ file: pkg.types, format: "es" }],
-    external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
+    external: externalDependencies,
     plugins: [dts()],
   },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,20 @@
 import typescript from "rollup-plugin-typescript2";
+import dts from "rollup-plugin-dts";
 const pkg = require("./package.json");
 
-export default {
-  input: ["src/index.ts"],
-  output: [{ file: pkg.main, format: "cjs", sourcemap: true }],
-  external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
-  plugins: [typescript({ clean: true })],
-};
+export default [
+  // Typescript
+  {
+    input: ["src/index.ts"],
+    output: [{ file: pkg.main, format: "cjs", sourcemap: true }],
+    external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
+    plugins: [typescript({ clean: true })],
+  },
+  // Data type declarations
+  {
+    input: ["src/index.ts"],
+    output: [{ file: pkg.types, format: "es" }],
+    external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
+    plugins: [dts()],
+  },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
-    "declaration": true,
+    "declaration": false,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10899,6 +10899,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rollup-plugin-dts@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-1.4.2.tgz#eabe4cee9f85c0ad04c8c75ee9c8781d1cc0ed40"
+  integrity sha512-Ghd3+p9rczMcoJcJ6uq7eaVpiw150u+fB8oHnNY/CMD25RgKijltRdWVGUE6de6fdnec3iR76naQk7LVXp97gQ==
+  optionalDependencies:
+    "@babel/code-frame" "^7.8.3"
+
 rollup-plugin-typescript2@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.27.0.tgz#95ff96f9e07d5000a9d2df4d76b548f9a1f83511"


### PR DESCRIPTION
## Proposed changes
Previously the package included all of the following files

```
>>> npm notice 217B   dist/components/0.welcome.stories.d.ts
    npm notice 712B   dist/components/Button/Button.d.ts
>>> npm notice 396B   dist/components/Button/Button.stories.d.ts
>>> npm notice 12B    dist/components/Button/Button.test.d.ts
    npm notice 257B   dist/components/Flexbox/Flexbox.d.ts
>>> npm notice 337B   dist/components/Flexbox/Flexbox.stories.d.ts
>>> npm notice 12B    dist/components/Flexbox/Flexbox.test.d.ts
    npm notice 229B   dist/components/Button/Icon.d.ts
    npm notice 99B    dist/components/Button/index.d.ts
    npm notice 59B    dist/components/Flexbox/index.d.ts
    npm notice 124B   dist/components/RadioButton/index.d.ts
    npm notice 120B   dist/index.d.ts
    npm notice 427B   dist/components/RadioButton/RadioButton.d.ts
>>> npm notice 273B   dist/components/RadioButton/RadioButton.stories.d.ts
>>> npm notice 12B    dist/components/RadioButton/RadioButton.test.d.ts
```

This indicated that the stories and test data types were also included
in the bundled code...

This code solves the problem by introducing dts bundling in just a
single file...
The output file (`dist/index.d.ts`) would only include the component
defined data types, saving space and not introducing a code that not
needed to be shipped with the code...

Side effect, since all the data types are rolled in 1 file, it can be
easier to see the type definitions together and search within the same
file

The output of the package should be the following files only
```
  dist/
  ├── index.d.ts
  ├── index.js
  └── index.js.map
```

## Text for the Changelog
Fix bundling d.ts definitions

- 🔧 Roll up the `d.ts` files when publishing the package