### PR TITLE
Fix/missing flex property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sapera-components",
-  "version": "0.0.8-development",
+  "version": "0.0.7-development",
   "description": "Sapera Design System and Storybook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sapera-components",
-  "version": "0.0.7-development",
+  "version": "0.0.9-development",
   "description": "Sapera Design System and Storybook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import styled from "styled-components";
 import { TickIcon } from "../Icon/Icons";
 import { Color } from "../../theme/util";
+import { Column } from "../../theme/custom-styled-components";
 
 const LABEL_SIZE = 24;
 const CHECKMARK_CLASSNAME = "checkmark";
@@ -81,7 +82,7 @@ export const Checkbox: FC<CheckboxProps> = ({
   disabled = false,
 }: CheckboxProps) => {
   return (
-    <div className={className}>
+    <Column className={className}>
       <LabelStyled htmlFor={id} onChange={onChange}>
         <InputStyled checked={checked} disabled={disabled} id={id} name={name} type="checkbox" value={value} />
         <CheckmarkStyled className={CHECKMARK_CLASSNAME}>
@@ -89,6 +90,6 @@ export const Checkbox: FC<CheckboxProps> = ({
         </CheckmarkStyled>
         {children}
       </LabelStyled>
-    </div>
+    </Column>
   );
 };


### PR DESCRIPTION
## Proposed changes

This Pull Request fixes a styling issue where we require `flex` CSS display property
in the `<Checkbox/>` component.

### Bug Fixes

- 🐛 Add missing display `flex` CSS property to the `<Checkbox/>` component.

### Technical

- 🗎 Bump release version from _0.0.8-development_ to _0.0.9-development_.

