### PR TITLE
Chore/add data attribute button prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sapera-components",
-  "version": "0.0.11-development",
+  "version": "0.0.12-development",
   "description": "Sapera Design System and Storybook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -16,20 +16,20 @@ const downloadIcon = <DownloadIcon height={25} width={25} />;
 export const TextButtons: React.FunctionComponent = () => (
   <div style={{ display: "flex", justifyContent: "space-around" }}>
     <Column alignItems="center" justifyContent="center">
-      <Button bg={"purple"} id="button-id" onClick={action("clicked")}>
+      <Button bg="purple" id="button-id" onClick={action("clicked")}>
         primary lg, custom bg
       </Button>
       <br />
       <Button
         data-test="data-attribute-test"
         data-test-two="data-attribute-test-two"
-        size={"medium"}
+        size="medium"
         onClick={action("clicked")}
       >
         primary md
       </Button>
       <br />
-      <Button size={"small"} onClick={action("clicked")}>
+      <Button size="small" onClick={action("clicked")}>
         primary sm
       </Button>
     </Column>
@@ -38,11 +38,11 @@ export const TextButtons: React.FunctionComponent = () => (
         Secondary lg
       </Button>
       <br />
-      <Button bg={"yellow"} size={"medium"} isSecondary onClick={action("clicked")}>
+      <Button bg="yellow" size="medium" isSecondary onClick={action("clicked")}>
         Secondary md
       </Button>
       <br />
-      <Button size={"small"} isSecondary onClick={action("clicked")}>
+      <Button size="small" isSecondary onClick={action("clicked")}>
         Secondary sm
       </Button>
     </Column>
@@ -56,11 +56,11 @@ export const TextWithIconButtons: React.FunctionComponent = () => (
         button
       </Button>
       <br />
-      <Button icon={downloadIcon} size={"medium"} iconFirst onClick={action("clicked")}>
+      <Button icon={downloadIcon} size="medium" iconFirst onClick={action("clicked")}>
         Button
       </Button>
       <br />
-      <Button icon={downloadIcon} size={"small"} onClick={action("clicked")}>
+      <Button icon={downloadIcon} size="small" onClick={action("clicked")}>
         Button
       </Button>
     </Column>
@@ -69,11 +69,11 @@ export const TextWithIconButtons: React.FunctionComponent = () => (
         Download
       </Button>
       <br />
-      <Button icon={downloadIcon} size={"medium"} isSecondary onClick={action("clicked")}>
+      <Button icon={downloadIcon} size="medium" isSecondary onClick={action("clicked")}>
         Download
       </Button>
       <br />
-      <Button icon={downloadIcon} size={"small"} iconFirst isSecondary onClick={action("clicked")}>
+      <Button icon={downloadIcon} size="small" iconFirst isSecondary onClick={action("clicked")}>
         Download
       </Button>
     </Column>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -20,7 +20,12 @@ export const TextButtons: React.FunctionComponent = () => (
         primary lg, custom bg
       </Button>
       <br />
-      <Button size={"medium"} onClick={action("clicked")}>
+      <Button
+        data-test="data-attribute-test"
+        data-test-two="data-attribute-test-two"
+        size={"medium"}
+        onClick={action("clicked")}
+      >
         primary md
       </Button>
       <br />

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import styled, { css } from "styled-components";
 import { Color, ColorType } from "../../theme/util";
+import dataAttributeProps, { DataAttributePropsType } from "../../utils/dataAttributeProps";
 
 // https://www.w3schools.com/tags/tag_button.asp
 export interface ButtonProps {
@@ -23,6 +24,7 @@ export interface ButtonProps {
   onClick?: () => void;
   width?: string;
   id?: string;
+  props?: unknown;
 }
 
 interface StyledButtonProps extends ButtonProps {
@@ -114,6 +116,7 @@ export const Button: FC<ButtonProps> = ({
   isSecondary = false,
   bg = isSecondary ? "none" : Color.Primary,
   value,
+  ...props
 }: ButtonProps) => {
   // aria-label atrribute usage
   // developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
@@ -141,6 +144,7 @@ export const Button: FC<ButtonProps> = ({
       value={value}
       width={width}
       onClick={disabled ? () => null : onClick}
+      {...dataAttributeProps(props as DataAttributePropsType)}
     >
       <span>{children}</span>
       {icon && icon}

--- a/src/utils/dataAttributeProps.ts
+++ b/src/utils/dataAttributeProps.ts
@@ -1,0 +1,16 @@
+export interface DataAttributePropsType {
+  [x: string]: unknown;
+  props?: unknown;
+}
+
+const dataAttributeProps = (props: DataAttributePropsType) => {
+  const newProps: { [key: string]: unknown } = {};
+
+  Object.keys(props).forEach((key) => {
+    if (key.startsWith("data-") || key === "className") newProps[key] = props[key];
+  });
+
+  return newProps;
+};
+
+export default dataAttributeProps;


### PR DESCRIPTION
## Proposed changes

This Pull Request adds a helper function called `dataAttributeProps()` in the utility folder to add data-* attributes to any components. The helper function is used in the `<Button/>` component.

<img width="1653" alt="Screenshot 2020-09-17 at 08 32 32" src="https://user-images.githubusercontent.com/2966898/93428800-5f082500-f8c0-11ea-96a1-e89410d35c00.png">

### Features

- 🚀 Adds a helper function called `dataAttributeProps()` to add data-* attributes to the `<Button/>` component.


### Technical

🔖  Update version tag from _0.0.11-development_ to _0.0.12-development_ for tag release.

## Ticket
part of
- [Integrate Submission Functionality 2.1](https://app.asana.com/0/1154394619859001/1190069648922489)