### PR TITLE
style: change gap size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sapera-components",
-"version": "0.0.12-development",
+  "version": "0.0.13-development",
   "description": "Sapera Design System and Storybook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sapera-components",
-  "version": "0.0.12-development",
+"version": "0.0.12-development",
   "description": "Sapera Design System and Storybook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/components/CirclePagination/CirclePagination.tsx
+++ b/src/components/CirclePagination/CirclePagination.tsx
@@ -27,13 +27,7 @@ export const CirclePagination: FC<CirclePaginationProps> = ({
   className,
 }: CirclePaginationProps) => {
   return (
-    <Grid
-      className={className}
-      display="inline-grid"
-      gridAutoFlow="column"
-      gridGap={{ xxs: 60, lg: 120 }}
-      justifyContent="flex-start"
-    >
+    <Grid className={className} display="inline-grid" gridAutoFlow="column" gridGap={50} justifyContent="flex-start">
       {data.map((item: any, index: number) => {
         return (
           <ButtonStyled


### PR DESCRIPTION
## Proposed changes

As requested by the designer, this Pull Request edits the grid's gap spacing in the `<CirclePagination/>` component of the buttons.

## Text for the Changelog

_before_
<img width="1543" alt="Screenshot 2020-10-09 at 10 49 53" src="https://user-images.githubusercontent.com/2966898/95563283-7ea4f000-0a1d-11eb-8882-9b1ebe274718.png">

_after_
<img width="1543" alt="Screenshot 2020-10-09 at 10 49 37" src="https://user-images.githubusercontent.com/2966898/95563293-806eb380-0a1d-11eb-8263-ad9975349151.png">

## Ticket

- [Less padding at carousel points](https://app.asana.com/0/1154394619859001/1197811138258710)

## Note
- I will make a release and update the pattern library version number in the [sapera-website](https://github.com/infographicsgroup/sapera-website) repository once we merge this ticket.
