### PR TITLE
style: update button padding

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -42,8 +42,8 @@ const BUTTON_HEIGHTS = {
 };
 
 const BUTTON_PADDING = {
-  large: "0 35",
-  medium: "0 30",
+  large: "0 48",
+  medium: "0 48",
   small: "0 25",
 };
 
@@ -51,6 +51,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   display: flex;
   justify-content: center;
   align-items: center;
+  align-self: center;
   flex-direction: row;
   width: ${(p) => p.width};
   height: ${(p) => (p.size ? BUTTON_HEIGHTS[p.size] + "px" : BUTTON_HEIGHTS.large + "px")};


### PR DESCRIPTION
## Proposed changes

Update button paddings per design request for all small, medium and large. Example pictures are of secondary buttons, but it applies to primary too.

_Before_

<img width="307" alt="Screen Shot 2020-10-13 at 15 23 06" src="https://user-images.githubusercontent.com/15083303/95866260-006f8300-0d68-11eb-8d29-469ef7d5b87b.png">


_After_

<img width="255" alt="Screen Shot 2020-10-13 at 14 16 11" src="https://user-images.githubusercontent.com/15083303/95866158-d7e78900-0d67-11eb-890b-0424a18bb7f1.png">


### Technical

- 🌈 Update button paddings

## Ticket

- [Inquiry button too wide on desktop](https://app.asana.com/0/1154394619859001/1197811138258885)
