### PR TITLE
Style/checkbox bg

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -60,7 +60,6 @@ const CheckmarkStyled = styled.span`
   width: ${LABEL_SIZE}px;
   height: ${LABEL_SIZE}px;
   z-index: 1;
-  background-color: ${Color.BackgroundMain};
   border: 2px solid ${Color.Primary};
   border-radius: 5px;
 


### PR DESCRIPTION
## Proposed changes

Fixes error found in [Checkbox PR](https://github.com/infographicsgroup/sapera-components/pull/40). The checkbox component now has no background color, so it's flexible with different backgrounds

### _Before_

<img width="853" alt="Screen Shot 2020-10-20 at 12 06 20" src="https://user-images.githubusercontent.com/15083303/96573128-00becf80-12ce-11eb-8510-60e7bced9010.png">


### _After (orange background as an example only)_

<img width="429" alt="Screen Shot 2020-10-20 at 12 05 51" src="https://user-images.githubusercontent.com/15083303/96573137-03b9c000-12ce-11eb-9ea7-7d0db1b5bb8b.png">

### Technical

- 🌈 Remove background color

